### PR TITLE
Change syntax to puppet 4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,11 +62,11 @@
 
 # lint:ignore:undef_in_function
 define sensu_check_wrapper (
-  Regexp['^[\w\.-]+$'] $_name = $name,
+  Pattern['^[\w\.-]+$'] $_name = $name,
   String $command,
-  Regexp['^https?://'] $runbook,
+  Pattern['^https?://'] $runbook,
   Enum['present', 'absent'] $ensure = 'present',
-  Optional[Regexp['^[\w\.-]+$']] $group = undef,
+  Optional[Pattern['^[\w\.-]+$']] $group = undef,
   String $check_every = pick(
     hiera("sensu_check_wrapper::check_every::${title}", undef),
     hiera("sensu_check_wrapper::check_every::group::${group}", undef),
@@ -115,7 +115,7 @@ define sensu_check_wrapper (
     hiera('sensu_check_wrapper::handle', undef),
     true
   ),
-  Optional[Regexp['^https?://']] $uchiwa_prefix = hiera('sensu_check_wrapper::uchiwa_prefix', undef),
+  Optional[Pattern['^https?://']] $uchiwa_prefix = hiera('sensu_check_wrapper::uchiwa_prefix', undef),
 ) {
 # lint:endignore
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,11 +146,11 @@ define sensu_check_wrapper (
   $sensu_check_params = {
     command     => $command,
     ensure      => $ensure,
-    interval    => $interval_s,
+    interval    => 0 + $interval_s,
     handlers    => $handlers,
     occurrences => $occurrences,
     subdue      => $subdue,
-    refresh     => $refresh_s,
+    refresh     => 0 + $refresh_s,
     aggregate   => $_aggregate,
     handle      => $_handle,
     custom      => $custom,


### PR DESCRIPTION
Two corrections:

- rewrite validate_* functions to standard data type definition
- $interval and $refresh expects in ::sensu::check from module sensu/sensu v. 2.53.0 to be integer, but getting strings